### PR TITLE
Implement checked addition and substraction

### DIFF
--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -24,6 +24,14 @@ impl Instant {
 	pub fn saturating_duration_since(&self, earlier: Instant) -> Duration {
 		self.0 - earlier.0
 	}
+	#[inline]
+	pub fn checked_add(&self, duration: Duration) -> Option<Instant> {
+		self.0.checked_add(duration).map(Instant)
+	}
+	#[inline]
+	pub fn checked_sub(&self, duration: Duration) -> Option<Instant> {
+		self.0.checked_sub(duration).map(Instant)
+	}
 }
 
 fn duration_from_f64(millis: f64) -> Duration {


### PR DESCRIPTION
Implement the checked variants of addition and subtraction, which return an option. This change is required for [this SurrealDB PR](https://github.com/surrealdb/surrealdb/pull/3258), which fixes a panic when addition would overflow. Currently the PR fails to build for WASM due to the `checked_add` method not being implemented. Similar implementations are [present in comparable libraries](https://github.com/sebcrozet/instant/blob/master/src/wasm.rs#L36-L50).

